### PR TITLE
Add C# equivalents for entity classes

### DIFF
--- a/csharp/Entities/Cart.cs
+++ b/csharp/Entities/Cart.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+
+namespace PhpSales.Entities
+{
+    public class Cart
+    {
+        private readonly List<Item> _items = new();
+        private double _total = 0.0;
+        private double _tax = 0.0;
+
+        public void AddItem(Item item)
+        {
+            _items.Add(item);
+            Calculate();
+        }
+
+        public IReadOnlyList<Item> GetItems()
+        {
+            return _items.AsReadOnly();
+        }
+
+        public double GetTotal()
+        {
+            return _total;
+        }
+
+        public double GetTax()
+        {
+            return _tax;
+        }
+
+        public void EditItem(int index, Item item)
+        {
+            try
+            {
+                if (index >= 0 && index < _items.Count)
+                {
+                    _items[index] = item;
+                    Calculate();
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Cart.cs EditItem: " + e.Message);
+            }
+        }
+
+        public void RemoveItem(int index)
+        {
+            try
+            {
+                if (index >= 0 && index < _items.Count)
+                {
+                    _items.RemoveAt(index);
+                    Calculate();
+                }
+            }
+            catch (Exception e)
+            {
+                Console.WriteLine("Cart.cs RemoveItem: " + e.Message);
+            }
+        }
+
+        private void Calculate()
+        {
+            _total = 0.0;
+            _tax = 0.0;
+
+            foreach (var item in _items)
+            {
+                _total += item.TaxedPrice;
+                _tax += item.Taxes;
+            }
+        }
+    }
+}

--- a/csharp/Entities/Item.cs
+++ b/csharp/Entities/Item.cs
@@ -1,0 +1,16 @@
+using System;
+
+namespace PhpSales.Entities
+{
+    public class Item
+    {
+        public string ItemType { get; set; }
+        public string Name { get; set; }
+        public double Price { get; set; }
+        public double Taxes { get; set; }
+        public double TaxedPrice { get; set; }
+        public double TaxPercentage { get; set; }
+        public int Quantity { get; set; }
+        public bool Imported { get; set; }
+    }
+}

--- a/csharp/Entities/Taxes.cs
+++ b/csharp/Entities/Taxes.cs
@@ -1,0 +1,10 @@
+namespace PhpSales.Entities
+{
+    public static class Taxes
+    {
+        public const int book = 0;
+        public const int food = 0;
+        public const int medical_products = 0;
+        public const int other = 10;
+    }
+}


### PR DESCRIPTION
## Summary
- set up a new `csharp/Entities` folder
- implement `Item`, `Cart`, and `Taxes` classes in C#
- re-create cart methods (add, edit, remove, calculate)

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6856feba84788321981555f3995d9770