### PR TITLE
Add C# sample runner

### DIFF
--- a/csharp/Program.cs
+++ b/csharp/Program.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using PhpSales.Entities;
+using PhpSales.Services;
+
+namespace PhpSales
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            var inputs = new Dictionary<int, List<string>>
+            {
+                [1] = new List<string>
+                {
+                    "2 book at 12.49",
+                    "1 music CD at 14.99",
+                    "1 chocolate bar at 0.85"
+                },
+                [2] = new List<string>
+                {
+                    "1 imported box of chocolates at 10.00",
+                    "1 imported bottle of perfume at 47.50"
+                },
+                [3] = new List<string>
+                {
+                    "1 imported bottle of perfume at 27.99",
+                    "1 bottle of perfume at 18.99",
+                    "1 packet of headache pills at 9.75",
+                    "3 box of imported chocolates at 11.25"
+                },
+                [4] = new List<string>
+                {
+                    "2 bottle of perfume imported at 27.99",
+                    "1 bottle of imported perfume at 18.99",
+                    "4 packet of imported headache pills at 9.75",
+                    "3 box of chocolates at 11.25"
+                }
+            };
+
+            var inputParser = new InputParser();
+            var carts = new Dictionary<int, Cart>();
+            int cartNumber = 1;
+
+            foreach (var entry in inputs)
+            {
+                Console.WriteLine($"Input {cartNumber}:");
+                carts[cartNumber] = new Cart();
+
+                foreach (var line in entry.Value)
+                {
+                    Console.WriteLine(line);
+                    carts[cartNumber].AddItem(inputParser.Parse(line));
+                }
+
+                Console.WriteLine();
+                cartNumber++;
+            }
+
+            Console.WriteLine("OUTPUT");
+            for (int i = 1; i < cartNumber; i++)
+            {
+                Console.WriteLine();
+                Console.WriteLine($"Output {i}:");
+                OutputFormatter.PrintCart(carts[i]);
+            }
+        }
+    }
+}

--- a/csharp/Services/InputParser.cs
+++ b/csharp/Services/InputParser.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public class InputParser
+    {
+        private static readonly Dictionary<string, string> ITEMTYPE = new()
+        {
+            {"book", "book"},
+            {"music CD", "other"},
+            {"chocolate bar", "food"},
+            {"box of chocolates", "food"},
+            {"bottle of perfume", "other"},
+            {"packet of headache pills", "medical_products"}
+        };
+
+        public Item Parse(string text)
+        {
+            if (string.IsNullOrWhiteSpace(text))
+                throw new ArgumentException("Input text cannot be null", nameof(text));
+
+            text = text.Trim();
+
+            int quantityEnd = text.IndexOf(' ');
+            var item = new Item();
+            item.Quantity = int.Parse(text.Substring(0, quantityEnd));
+
+            int atPos = text.LastIndexOf(" at ");
+            item.Price = double.Parse(text[(atPos + 4)..], CultureInfo.InvariantCulture);
+
+            string namePart = text.Substring(quantityEnd + 1, atPos - (quantityEnd + 1)).Trim();
+
+            int importedIndex = namePart.IndexOf("imported", StringComparison.Ordinal);
+            if (importedIndex >= 0)
+            {
+                item.Imported = true;
+                item.TaxPercentage = 5;
+                namePart = (namePart.Remove(importedIndex, "imported".Length)).Trim();
+                item.Name = $"imported {namePart}";
+            }
+            else
+            {
+                item.Imported = false;
+                item.TaxPercentage = 0;
+                item.Name = namePart;
+            }
+
+            string typeKey = namePart;
+            if (!ITEMTYPE.TryGetValue(typeKey, out var itemType))
+            {
+                itemType = "other";
+            }
+            item.ItemType = itemType;
+
+            item.TaxPercentage += itemType switch
+            {
+                "book" => Taxes.book,
+                "food" => Taxes.food,
+                "medical_products" => Taxes.medical_products,
+                _ => Taxes.other
+            };
+
+            item.Taxes = item.Quantity * TaxCalculator.CalculateTaxes(item);
+            item.TaxedPrice = (item.Quantity * item.Price) + item.Taxes;
+
+            return item;
+        }
+    }
+}

--- a/csharp/Services/OutputFormatter.cs
+++ b/csharp/Services/OutputFormatter.cs
@@ -1,0 +1,23 @@
+using System;
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public static class OutputFormatter
+    {
+        private static string FormatItem(Item item)
+        {
+            return $"{item.Quantity} {item.Name}: {item.TaxedPrice:F2}";
+        }
+
+        public static void PrintCart(Cart cart)
+        {
+            foreach (var item in cart.GetItems())
+            {
+                Console.WriteLine(FormatItem(item));
+            }
+            Console.WriteLine($"Sales Taxes: {cart.GetTax():F2}");
+            Console.WriteLine($"Total: {cart.GetTotal():F2}");
+        }
+    }
+}

--- a/csharp/Services/TaxCalculator.cs
+++ b/csharp/Services/TaxCalculator.cs
@@ -1,0 +1,17 @@
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public static class TaxCalculator
+    {
+        public static double CalculateTaxes(Item item)
+        {
+            double taxes = (item.Price / 100.0) * item.TaxPercentage;
+            if (taxes > 0)
+            {
+                taxes = System.Math.Ceiling(taxes * 20) / 20;
+            }
+            return taxes;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create Program.cs under csharp to run the example inputs
- add C# InputParser, OutputFormatter and TaxCalculator services for parity with PHP code

## Testing
- `php -l public/index.php` *(fails: command not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857009f114c8321bc4df1ef3eb3ab50