### PR TITLE
Add equivalent C# service classes

### DIFF
--- a/csharp/Services/InputParser.cs
+++ b/csharp/Services/InputParser.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public class InputParser
+    {
+        private string? _text;
+        private Item? _item;
+
+        private static readonly Dictionary<string, string> ItemTypeMap = new()
+        {
+            {"book", "book"},
+            {"music CD", "other"},
+            {"chocolate bar", "food"},
+            {"box of chocolates", "food"},
+            {"bottle of perfume", "other"},
+            {"packet of headache pills", "medical_products"}
+        };
+
+        public InputParser(string? text = null)
+        {
+            _text = text;
+            _item = null;
+        }
+
+        public void SetText(string text)
+        {
+            _text = text;
+            _item = null;
+        }
+
+        public Item Parse(string? text = null)
+        {
+            if (text != null)
+            {
+                SetText(text);
+            }
+
+            if (_item != null)
+            {
+                return _item!;
+            }
+
+            if (_text == null)
+            {
+                throw new ArgumentException("Input text cannot be null");
+            }
+
+            Item item = new();
+            string line = _text.Trim();
+
+            int firstSpace = line.IndexOf(' ');
+            item.Quantity = int.Parse(line.Substring(0, firstSpace));
+
+            int atPos = line.LastIndexOf("at", StringComparison.Ordinal);
+            item.Price = double.Parse(line.Substring(atPos + 2).Trim(), CultureInfo.InvariantCulture);
+
+            string description = line.Substring(firstSpace, atPos - firstSpace).Trim();
+
+            int importedIndex = description.IndexOf("imported", StringComparison.Ordinal);
+            if (importedIndex == -1)
+            {
+                item.Imported = false;
+                item.TaxPercentage = 0;
+                item.Name = description;
+            }
+            else
+            {
+                item.Imported = true;
+                item.TaxPercentage = 5;
+                string withoutImported = (description.Substring(0, importedIndex) + " " + description.Substring(importedIndex + 8)).Trim();
+                item.Name = "imported " + withoutImported;
+                description = withoutImported;
+            }
+
+            item.ItemType = ItemTypeMap.ContainsKey(description) ? ItemTypeMap[description] : "other";
+            item.TaxPercentage += item.ItemType switch
+            {
+                "book" => Taxes.book,
+                "food" => Taxes.food,
+                "medical_products" => Taxes.medical_products,
+                _ => Taxes.other
+            };
+
+            item.Taxes = item.Quantity * TaxCalculator.CalculateTaxes(item);
+            item.TaxedPrice = (item.Quantity * item.Price) + item.Taxes;
+
+            _item = item;
+            return _item;
+        }
+    }
+}

--- a/csharp/Services/OutputFormatter.cs
+++ b/csharp/Services/OutputFormatter.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Globalization;
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public static class OutputFormatter
+    {
+        private static string FormatItem(Item item)
+        {
+            return $"{item.Quantity} {item.Name}: {item.TaxedPrice.ToString("F2", CultureInfo.InvariantCulture)}";
+        }
+
+        public static void PrintCart(Cart cart)
+        {
+            foreach (var item in cart.GetItems())
+            {
+                string formatted = FormatItem(item);
+                Console.WriteLine(formatted + "<br />\n");
+            }
+
+            Console.WriteLine($"Sales Taxes: {cart.GetTax().ToString("F2", CultureInfo.InvariantCulture)}<br />\n");
+            Console.WriteLine($"Total: {cart.GetTotal().ToString("F2", CultureInfo.InvariantCulture)}<br />\n");
+        }
+    }
+}

--- a/csharp/Services/TaxCalculator.cs
+++ b/csharp/Services/TaxCalculator.cs
@@ -1,0 +1,18 @@
+using System;
+using PhpSales.Entities;
+
+namespace PhpSales.Services
+{
+    public static class TaxCalculator
+    {
+        public static double CalculateTaxes(Item item)
+        {
+            double taxes = (item.Price / 100) * item.TaxPercentage;
+            if (taxes > 0)
+            {
+                taxes = Math.Ceiling(taxes * 20) / 20;
+            }
+            return taxes;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `InputParser` in C# for parsing items
- add `OutputFormatter` to print cart results
- port PHP rounding logic in `TaxCalculator`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68570099cf0c83219450fca582a573fd